### PR TITLE
Pre-fill the correct input when accepting a revision

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "description": "Adding Test Policy UI to Phabricator",
   "manifest_version": 2,
   "name": "phab-test-policy",
-  "version": "1.3",
+  "version": "1.4",
   "homepage_url": "https://github.com/nchevobbe/phab-test-policy",
   "icons": {},
   "permissions": [
@@ -27,7 +27,7 @@
   ],
   "applications": {
     "gecko": {
-      "strict_min_version": "81.0"
+      "strict_min_version": "78.0"
     }
   }
 }

--- a/test-policy.js
+++ b/test-policy.js
@@ -4,10 +4,33 @@ const TYPES = {
 };
 const ACCEPT_TYPE = "accept";
 
+const projectTagsData = Array.from(
+  document.querySelectorAll("data[data-javelin-init-kind=behaviors]")
+)
+  .map((d) => JSON.parse(d.getAttribute("data-javelin-init-data")))
+  .find((data) => data["comment-actions"])
+  ?.["comment-actions"].find(({ actions }) => actions?.projectPHIDs)?.actions
+  ?.projectPHIDs;
+
 // We don't have access to the project tag label directly, so we need to retrieve their ids
 // We re-use the URL that the project tag autocomplete is using (using Phabricator API requires a token).
+const src =
+  projectTagsData?.spec?.config?.src ||
+  "/typeahead/class/PhabricatorProjectDatasource/";
+
+// The input doesn't have meaningful attribute data we could target, and worse, the same
+// class is used for all the "type ahead" inputs (e.g. reviewers)
+// Luckily, we might have some data in projectTagsData, where the markup that will be used
+// for the project tag input is stored.
+let dataMeta;
+if (projectTagsData?.spec?.markup) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(projectTagsData.spec.markup, "text/html");
+  dataMeta = doc.querySelector("[data-meta]").getAttribute("data-meta");
+}
+
 var projectTagsIdsPromise = fetch(
-  "https://phabricator.services.mozilla.com/typeahead/class/PhabricatorProjectDatasource/?q=testing-&__ajax__=true"
+  `https://phabricator.services.mozilla.com${src}?q=testing-&__ajax__=true`
 )
   .then((res) => res.text())
   .then((responseText) => {
@@ -84,7 +107,27 @@ browser.runtime.onMessage.addListener(async function onBackgroundMessage(
       select.dispatchEvent(new Event("change"));
 
       setTimeout(() => {
-        const autocompleteEl = document.querySelector(".jx-tokenizer-input");
+        let projectTagInputSelector = ".jx-tokenizer-input";
+        // By default, let's retrieve the first input we find (so if we can't refine the
+        // search, we'll have an input, that is likely to be the project tag one).
+        let autocompleteEl = document.querySelector(projectTagInputSelector);
+
+        // If we were able to retrieve a dataMeta value for the project tags
+        if (dataMeta) {
+          // The data-meta is set on a span which is a sibling of the input, so we query
+          // from containers in order to find it.
+          const container = Array.from(
+            document.querySelectorAll(".jx-tokenizer-frame")
+          ).find((el) => el.querySelector(`[data-meta="${dataMeta}"]`));
+          // If we did find it, then we're going to try to retrieve the input in the container.
+          if (container) {
+            const input = container.querySelector(projectTagInputSelector);
+            if (input) {
+              autocompleteEl = input;
+            }
+          }
+        }
+
         autocompleteEl.focus();
         autocompleteEl.value = "testing-";
         autocompleteEl.dispatchEvent(new Event("keydown"));


### PR DESCRIPTION
Fix #5, #6 
When accepting the revision, we were doing a simple query
to retrieve the project id input and prefill it with the
testing tag prefix.
But it might happen that the user have other inputs displayed (e.g. Reviewers),
and the selector we're using is the same, so we'd fill the wrong input.

Unfortunately, there's no meaningful attributes that could only target the
project tags input.
Luckily, there's a <data> element on the page that has some data about project
ids, and more specifically, the markup that will be used to render the input,
where what seems to be a unique data-meta id is used.
So here, at startup we retrieve this id, and when accepting the revision, we
check the element with this data-meta attribute, and retrieve the sibling
input.

---

Change min version to esr and update version

